### PR TITLE
Corrected zone storage for slave zones file creation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,8 @@ WEBMIN_DATA_DIR=${DATA_DIR}/webmin
 
 create_bind_data_dir() {
   mkdir -p ${BIND_DATA_DIR}
-  chmod -R 0755 ${BIND_DATA_DIR}
-  chown -R root:${BIND_USER} ${BIND_DATA_DIR}
+  chmod -R 0775 ${BIND_DATA_DIR}
+  chown -R ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}
 
   # populate default bind configuration if it does not exist
   if [ ! -d ${BIND_DATA_DIR}/etc ]; then
@@ -21,7 +21,7 @@ create_bind_data_dir() {
 
   if [ ! -d ${BIND_DATA_DIR}/lib ]; then
     mkdir -p ${BIND_DATA_DIR}/lib
-    chown root:${BIND_USER} ${BIND_DATA_DIR}/lib
+    chown ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}/lib
   fi
   rm -rf /var/lib/bind
   ln -sf ${BIND_DATA_DIR}/lib /var/lib/bind


### PR DESCRIPTION
Hi !

I corrected a permission problem that prevented bind to be able to access the zone files, therefore rendering the use of slave zones impossible ;)

I tested this with several slave zones, stopped/killed/recreated the container with its external data storage, everything seems to be working correctly now, as expected !

Hope that'll help ! :)

PS : I think this might be the resolution for #5 