### PR TITLE
Open ports 10000-10010 to allow RPC communication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN rm -rf /etc/apt/apt.conf.d/docker-gzip-indexes \
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
 
-EXPOSE 53/udp 53/tcp 10000/tcp
+EXPOSE 53/udp 53/tcp 10000-10010/tcp
 ENTRYPOINT ["/sbin/entrypoint.sh"]
 CMD ["/usr/sbin/named"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Start BIND using:
 
 ```bash
 docker run --name bind -d --restart=always \
-  --publish 53:53/tcp --publish 53:53/udp --publish 10000:10000/tcp \
+  --publish 53:53/tcp --publish 53:53/udp --publish 10000-10010:10000-10010/tcp \
   --volume /srv/docker/bind:/data \
   sameersbn/bind:9.9.5-20170626
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     ports:
     - "53:53/udp"
     - "53:53/tcp"
-    - "10000:10000/tcp"
+    - "10000-10010:10000-10010/tcp"
     volumes:
     - /srv/docker/bind:/data


### PR DESCRIPTION
Webmin uses ports 10000-100010 for RPC communication. When setting up a bind slave, Webmin uses these extra ports for communication.

> What ports does Webmin RPC use>
> Webmin has two RPC modes - slow mode, that only uses the same HTTP port the webserver listens on (typically 10000), and fast mode which uses ports 10000 on up. The upper bound depends on the number of concurrent RPC operations, but opening the range 10000 to 10010 should be enough when configuring the firewall between two Webmin servers.

http://www.webmin.com/faq.html