### PR TITLE
Support for seed files to create swarm-enabled immutable containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,5 @@ COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
 
 EXPOSE 53/udp 53/tcp 10000/tcp
-VOLUME ["${DATA_DIR}"]
 ENTRYPOINT ["/sbin/entrypoint.sh"]
 CMD ["/usr/sbin/named"]


### PR DESCRIPTION
By allowing the user to create a custom derived image from this one just adding his own configuration files, you can create immutable containers that are suitable to be deployed on a docker swarm.