### PR TITLE
Allow disabling chown

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,11 +17,15 @@ create_bind_data_dir() {
   rm -rf /etc/bind
   ln -sf ${BIND_DATA_DIR}/etc /etc/bind
   chmod -R 0775 ${BIND_DATA_DIR}
-  chown -R ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}
+  if [ "$NO_CHOWN" != true ]; then
+    chown -R ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}
+  fi
 
   if [ ! -d ${BIND_DATA_DIR}/lib ]; then
     mkdir -p ${BIND_DATA_DIR}/lib
-    chown ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}/lib
+    if [ "$NO_CHOWN" != true ]; then
+      chown ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}/lib
+    fi
   fi
   rm -rf /var/lib/bind
   ln -sf ${BIND_DATA_DIR}/lib /var/lib/bind
@@ -30,7 +34,9 @@ create_bind_data_dir() {
 create_webmin_data_dir() {
   mkdir -p ${WEBMIN_DATA_DIR}
   chmod -R 0755 ${WEBMIN_DATA_DIR}
-  chown -R root:root ${WEBMIN_DATA_DIR}
+  if [ "$NO_CHOWN" != true ]; then
+    chown -R root:root ${WEBMIN_DATA_DIR}
+  fi
 
   # populate the default webmin configuration if it does not exist
   if [ ! -d ${WEBMIN_DATA_DIR}/etc ]; then
@@ -46,12 +52,16 @@ set_root_passwd() {
 
 create_pid_dir() {
   mkdir -m 0775 -p /var/run/named
-  chown root:${BIND_USER} /var/run/named
+  if [ "$NO_CHOWN" != true ]; then
+    chown root:${BIND_USER} /var/run/named
+  fi
 }
 
 create_bind_cache_dir() {
   mkdir -m 0775 -p /var/cache/bind
-  chown root:${BIND_USER} /var/cache/bind
+  if [ "$NO_CHOWN" != true ]; then
+    chown root:${BIND_USER} /var/cache/bind
+  fi
 }
 
 create_pid_dir


### PR DESCRIPTION
Invoking chown on the mounted volume might cause an error or inconvenience,
and it might not be necessary. Let's keep it by default for 'correctness', but
allow turning it off.