### PR TITLE
Fix pod.yml definition which fails on kubernetes 1.16.2

### DIFF
--- a/kubernetes/pod.yml
+++ b/kubernetes/pod.yml
@@ -10,7 +10,7 @@ spec:
       image: sameersbn/bind
       env:
         - name: WEBMIN_ENABLED
-          value: false
+          value: "false"
       ports:
         - containerPort: 53
           protocol: UDP


### PR DESCRIPTION
Seen on microk8s:
```
$ kubectl apply -f pod.yml
Error from server (BadRequest): error when creating "pod.yml": Pod in version "v1" cannot be handled as a Pod: v1.Pod.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found f, error found in #10 byte of ...|,"value":false}],"im|..., bigger context ...|iners":[{"env":[{"name":"WEBMIN_ENABLED","value":false}],"image":"sameersbn/bind","name":"bind","por|...
$
```
Quoting `false` to `"false"` seems to work.