### PR TITLE
Make webmin reverse-proxy friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ mkdir -p /srv/docker/bind
 chcon -Rt svirt_sandbox_file_t /srv/docker/bind
 ```
 
+## Reverse Proxying
+
+If you need to run Webmin behind a reverse-proxy such as Nginx, you can tweak the following environment variables:
+
+* `WEBMIN_INIT_SSL_ENABLED`: If Webmin should be served via SSL or not. Defaults to `true`. 
+   If you do the SSL termination at an earlier stage, set this to false.
+
+* `WEBMIN_INIT_REDIRECT_PORT`: The port Webmin is served from. 
+   Set this to your reverse proxy port, such as `443`. Defaults to `10000`.
+
+* `WEBMIN_INIT_REFERERS`: Sets the allowed referrers to Webmin. 
+   Set this to your domain name of the reverse proxy. Example: `mywebmin.example.com`. 
+   Defaults to empty (no referrer).
+
 # Maintenance
 
 ## Upgrading

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,7 @@ set_webmin_redirect_port() {
 }
 
 set_webmin_referers() {
-  echo "referers=$WEBMIN_REFERERS" >> /etc/webmin/config
+  echo "referers=$WEBMIN_INIT_REFERERS" >> /etc/webmin/config
 }
 
 set_root_passwd() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,9 @@ file_env 'ROOT_PASSWORD'
 
 ROOT_PASSWORD=${ROOT_PASSWORD:-password}
 WEBMIN_ENABLED=${WEBMIN_ENABLED:-true}
+WEBMIN_INIT_SSL_ENABLED=${WEBMIN_INIT_SSL_ENABLED:-true}
+WEBMIN_INIT_REDIRECT_PORT=${WEBMIN_INIT_REDIRECT_PORT:-10000}
+WEBMIN_INIT_REFERERS=${WEBMIN_INIT_REFERERS:-NONE}
 
 BIND_DATA_DIR=${DATA_DIR}/bind
 WEBMIN_DATA_DIR=${DATA_DIR}/webmin
@@ -64,6 +67,18 @@ create_webmin_data_dir() {
   ln -sf ${WEBMIN_DATA_DIR}/etc /etc/webmin
 }
 
+disable_webmin_ssl() {
+  sed -i 's/ssl=1/ssl=0/g' /etc/webmin/miniserv.conf
+}
+
+set_webmin_redirect_port() {
+  echo "redirect_port=$WEBMIN_INIT_REDIRECT_PORT" >> /etc/webmin/miniserv.conf
+}
+
+set_webmin_referers() {
+  echo "referers=$WEBMIN_REFERERS" >> /etc/webmin/config
+}
+
 set_root_passwd() {
   echo "root:$ROOT_PASSWORD" | chpasswd
 }
@@ -95,6 +110,13 @@ fi
 if [[ -z ${1} ]]; then
   if [ "${WEBMIN_ENABLED}" == "true" ]; then
     create_webmin_data_dir
+    if [ "${WEBMIN_INIT_SSL_ENABLED}" == "false" ]; then
+      disable_webmin_ssl
+    fi
+    set_webmin_redirect_port
+    if [ "${WEBMIN_INIT_REFERERS}" != "NONE" ]; then
+      set_webmin_referers
+    fi
     set_root_passwd
     echo "Starting webmin..."
     /etc/init.d/webmin start

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,6 +93,19 @@ create_bind_cache_dir() {
   chown root:${BIND_USER} /var/cache/bind
 }
 
+first_init() {
+  if [ ! -f /data/.initialized ]; then
+    set_webmin_redirect_port
+    if [ "${WEBMIN_INIT_SSL_ENABLED}" == "false" ]; then
+      disable_webmin_ssl
+    fi
+    if [ "${WEBMIN_INIT_REFERERS}" != "NONE" ]; then
+      set_webmin_referers
+    fi
+    touch /data/.initialized
+  fi
+}
+
 create_pid_dir
 create_bind_data_dir
 create_bind_cache_dir
@@ -110,13 +123,7 @@ fi
 if [[ -z ${1} ]]; then
   if [ "${WEBMIN_ENABLED}" == "true" ]; then
     create_webmin_data_dir
-    if [ "${WEBMIN_INIT_SSL_ENABLED}" == "false" ]; then
-      disable_webmin_ssl
-    fi
-    set_webmin_redirect_port
-    if [ "${WEBMIN_INIT_REFERERS}" != "NONE" ]; then
-      set_webmin_referers
-    fi
+    first_init
     set_root_passwd
     echo "Starting webmin..."
     /etc/init.d/webmin start


### PR DESCRIPTION
By adding the commonly used configuration parameters for this on initialization.