### PR TITLE
add env "BIND_LOG_STDERR" to control log

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ When the container is started the [Webmin](http://www.webmin.com/) service is al
 
 The launch of Webmin can be disabled by adding `--env WEBMIN_ENABLED=false` to the `docker run` command. Note that the `ROOT_PASSWORD` parameter has no effect when the launch of Webmin is disabled.
 
+To allow bind log to file by adding `--env BIND_LOG_STDERR=false` to the `docker run` command. That make bind not force all log to STDERR by using -f instead of -g to start the named process.
+
 Read the blog post [Deploying a DNS Server using Docker](http://www.damagehead.com/blog/2015/04/28/deploying-a-dns-server-using-docker/) for an example use case.
 
 ## Command-line arguments

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -132,7 +132,11 @@ if [[ -z ${1} ]]; then
   fi
 
   echo "Starting named..."
-  exec "$(command -v named)" -u ${BIND_USER} -g ${EXTRA_ARGS}
+  if [ "${BIND_LOG_STDERR:-true}" == "true" ]; then
+    exec "$(command -v named)" -u ${BIND_USER} -g ${EXTRA_ARGS}
+  else
+    exec "$(command -v named)" -u ${BIND_USER} -f ${EXTRA_ARGS}
+  fi
 else
   exec "$@"
 fi


### PR DESCRIPTION
named start with -g force all log output to STDERR. That is good for using "docker logs" to view log but it makes the named can't write log to file.
This change adds env "BIND_LOG_STDERR=false" so you can use -f to start named to allow to log to file.